### PR TITLE
Trivial improvements for CMake scripts

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,5 +1,5 @@
 cmake_minimum_required(VERSION 2.8)
-project(glob)
+project(glob-cpp)
 
 set(CMAKE_MODULE_PATH ${CMAKE_MODULE_PATH} "${CMAKE_SOURCE_DIR}/cmake/")
 
@@ -10,12 +10,15 @@ set(CMAKE_CXX_FLAGS_RELEASE "-O3")
 option(BUILD_UNIT_TESTS OFF)
 
 find_package(Boost REQUIRED COMPONENTS filesystem)
-include_directories(${Boost_INCLUDE_DIRS})
+
+add_library(${PROJECT_NAME} INTERFACE)
+target_include_directories(${PROJECT_NAME} INTERFACE ${Boost_INCLUDE_DIRS})
+target_include_directories(${PROJECT_NAME} INTERFACE ${CMAKE_CURRENT_SOURCE_DIR}/include)
+target_link_libraries(${PROJECT_NAME} INTERFACE ${Boost_FILESYSTEM_LIBRARY} ${Boost_SYSTEM_LIBRARY})
 
 if (BUILD_UNIT_TESTS)
   enable_testing()
   include(googletest)
-  include_directories(SYSTEM ${googletest_INCLUDE_DIRS}
-                      ${googlemock_INCLUDE_DIRS})
   add_subdirectory(tests)
 endif ()
+

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 2.8)
+cmake_minimum_required(VERSION 2.8.12)
 project(glob-cpp)
 
 set(CMAKE_MODULE_PATH ${CMAKE_MODULE_PATH} "${CMAKE_SOURCE_DIR}/cmake/")

--- a/include/glob-cpp/glob.h
+++ b/include/glob-cpp/glob.h
@@ -487,8 +487,9 @@ class StateGroup: public State<charT> {
     // STATE 1 -> is the next state
     // STATE 0 -> is the same state
     switch (type_) {
-      case Type::BASIC:
-      case Type::AT: {
+      // case Type::BASIC:
+      // case Type::AT:
+      default: {
         return NextBasic(str, pos);
         break;
       }

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -1,16 +1,15 @@
-include_directories(${CMAKE_SOURCE_DIR}/include)
-include_directories( ${GTEST_INCLUDE_DIRS})
-
 file(GLOB SOURCES_TEST ${CMAKE_CURRENT_SOURCE_DIR}/*.cc)
 foreach(local_file ${SOURCES_TEST} ${SOURCES_HASP_TEST})
   get_filename_component(local_filename ${local_file} NAME_WE)
 
   add_executable(${local_filename} ${local_file})
-  target_link_libraries(${local_filename}
+  target_include_directories(${local_filename} PRIVATE ${Boost_INCLUDE_DIRS} ${GTEST_INCLUDE_DIRS} ${googletest_INCLUDE_DIRS} ${googlemock_INCLUDE_DIRS})
+  target_link_libraries(${local_filename} glob-cpp
     ${CMAKE_THREAD_LIBS_INIT}
     ${googletest_MAIN_STATIC_LIBRARIES}
-    ${googletest_STATIC_LIBRARIES}
-    ${Boost_FILESYSTEM_LIBRARY}
-    ${Boost_SYSTEM_LIBRARY})
+    ${googletest_STATIC_LIBRARIES})
+  if (NOT WIN32)
+    target_link_libraries(${local_filename} pthread)
+  endif()
   add_test(UnitTests ${local_filename})
 endforeach()


### PR DESCRIPTION
Dear @alexst07 

This is a very useful project, thank you for working on it!

In this PR I offer cosmetic enhancements into the CMake build scripts, such that we could have a "pseudo" target for glob-cpp library. This target attaches include paths and boost libraries dependencies, so the user only needs to link against glob-cpp.

Kind regards,
- Dmitry.
- 