### PR TITLE
Fix clang warnigns

### DIFF
--- a/include/glob-cpp/glob.h
+++ b/include/glob-cpp/glob.h
@@ -354,6 +354,7 @@ template<class charT>
 class SetItem {
  public:
   SetItem() = default;
+  virtual ~SetItem() = default;
 
   virtual bool Check(charT c) const = 0;
 };
@@ -461,7 +462,7 @@ class StateGroup: public State<charT> {
       size_t pos) {
     String<charT> str_part = str.substr(pos);
     bool r;
-    size_t str_pos;
+    size_t str_pos = 0;
 
     // each automata is a part of a union of the group, in basic check,
     // we want find only if any automata is true
@@ -2006,7 +2007,7 @@ class AstConsumer {
   }
 
  private:
-  int preview_state_ = -1;
+  ssize_t preview_state_ = -1;
   size_t current_state_ = 0;
 };
 


### PR DESCRIPTION
Fix the following clang warnings (in Xcode 26.1):

```
/Users/tkukielk/Development/glob-cpp/include/glob-cpp/glob.h:1800:22: warning: implicit conversion loses integer precision: 'size_t' (aka 'unsigned long') to 'int' [-Wshorten-64-to-32]
 1800 |     preview_state_ = current_state_;
      |                    ~ ^~~~~~~~~~~~~~

/Applications/Xcode.app/Contents/Developer/Platforms/MacOSX.platform/Developer/SDKs/MacOSX26.1.sdk/usr/include/c++/v1/__memory/unique_ptr.h:78:5: warning: delete called on 'glob::SetItem<char>' that is abstract but has non-virtual destructor [-Wdelete-abstract-non-virtual-dtor]
   78 |     delete __ptr;
      |     ^

/Users/tkukielk/Development/glob-cpp/include/glob-cpp/glob.h:479:50: warning: variable 'str_pos' may be uninitialized when used here [-Wconditional-uninitialized]
  479 |     return std::tuple<bool, size_t>(false, pos + str_pos);
      |                                                  ^~~~~~~

/Users/tkukielk/Development/glob-cpp/include/glob-cpp/glob.h:465:19: note: initialize the variable 'str_pos' to silence this warning
  465 |     size_t str_pos;
      |                   ^
      |                    = 0
```