### PR TITLE
Plain "C" wrapper for glob-cpp

### DIFF
--- a/examples/cglob.cpp
+++ b/examples/cglob.cpp
@@ -1,0 +1,44 @@
+// cglob.cpp
+// Plain C wrapper for glob-cpp
+
+#include "glob.h"
+#include "cglob.h"
+#include <string>
+#include <new>
+
+// This code assumes glob::glob public APIs are exception-safe (no throw on invalid pattern)
+
+glob_t glob_create(const char *pattern, int /*flags*/)
+{
+    if (pattern == nullptr) {
+    	return nullptr;
+	}
+	
+    // Non-throwing new returns nullptr on allocation failure
+    return new (std::nothrow) glob::glob(pattern);
+}
+
+void glob_free(glob_t g)
+{
+    delete static_cast<glob::glob*>(g); // delete is null-safe
+}
+
+int glob_match(const glob_t g, const char *str)
+{
+    if (g == nullptr || str == nullptr) {
+    	return -1;
+	}
+	
+    auto *matcher = static_cast<glob::glob*>(g);
+    return glob::glob_match(std::string(str), *matcher) ? 0 : 1;
+}
+
+int glob_match_pattern(const char *pattern, const char *str, int /*flags*/)
+{
+    if (pattern == nullptr || str == nullptr) {
+    	return -1;
+	}
+	
+    glob::glob g(pattern);
+    return glob::glob_match(std::string(str), g) ? 0 : 1;
+}

--- a/examples/cglob.h
+++ b/examples/cglob.h
@@ -1,0 +1,66 @@
+/* cglob.h */
+#ifndef CGLOB_H
+#define CGLOB_H
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+#include <stddef.h>
+
+/**
+ * Opaque handle representing a compiled glob pattern.
+ */
+typedef void* glob_t;
+
+/* Flags are reserved for future use (currently ignored) */
+#define GLOB_NO_FLAGS 0
+
+/**
+ * Compile a glob pattern.
+ *
+ * @param pattern  Null-terminated UTF-8 glob pattern (e.g. '*.txt').
+ * @param flags    Reserved for future use; pass GLOB_NO_FLAGS.
+ *
+ * @return Pointer to compiled glob object on success, NULL on failure
+ *         (invalid pattern, out of memory, etc.).
+ */
+glob_t glob_create(const char *pattern, int flags);
+
+/**
+ * Free a glob object previously created with glob_create().
+ *
+ * @param g  Handle returned by glob_create(), or NULL (no-op if NULL).
+ */
+void glob_free(glob_t g);
+
+/**
+ * Test whether a string matches a compiled glob pattern.
+ *
+ * @param g    Handle returned by glob_create() (must not be NULL).
+ * @param str  Null-terminated UTF-8 string to test.
+ *
+ * @return 0  = match
+ *         1  = no match
+ *        -1  = error (NULL input or invalid handle)
+ */
+int glob_match(const glob_t g, const char *str);
+
+/**
+ * One-shot pattern compilation and matching (convenience function).
+ *
+ * Equivalent to glob_create() + glob_match() + glob_free().
+ *
+ * @param pattern  Null-terminated UTF-8 glob pattern.
+ * @param str      Null-terminated UTF-8 string to test.
+ * @param flags    Reserved for future use; pass GLOB_NO_FLAGS.
+ *
+ * @return Same return codes as glob_match().
+ */
+int glob_match_pattern(const char *pattern, const char *str, int flags);
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif /* CGLOB_H */


### PR DESCRIPTION
For C clients, a simple wrapper around C++ code.
Allows for glob compilation once and multiple matching with:
```
glob_t glob_create(const char *pattern, int flags);
int glob_match(const glob_t g, const char *str);
void glob_free(glob_t g);
```

or a single API for one time use:
```
int glob_match_pattern(const char *pattern, const char *str, int flags);
```

Flags currently unused but reserved for future use. TODO: add case-insensitive option.

Usage:

```
glob_t *g = glob_create("*.cpp", GLOB_NO_FLAGS);
if (g != NULL) {
    int res = glob_match(g, "main.cpp");  // 0 on match
    glob_free(g);
}
```