### PR TITLE
Alternative brace expansion implementation

### DIFF
--- a/include/glob-cpp/file-glob.h
+++ b/include/glob-cpp/file-glob.h
@@ -4,6 +4,8 @@
 #include <iostream>
 #include <cstdlib>
 #include "glob.h"
+#include <boost/filesystem.hpp>
+#include <boost/range/iterator_range.hpp>
 
 namespace glob {
 

--- a/include/glob-cpp/glob.h
+++ b/include/glob-cpp/glob.h
@@ -693,8 +693,7 @@ class Lexer {
  public:
   static const char kEndOfInput = -1;
 
-    Lexer(const String<charT>& str)
-     : str_(str), pos_{0}, c_{str[0]}, brace_depth_{0}, paren_depth_{0}, bracket_depth_{0} {}
+    Lexer(const String<charT>& str): str_(str), c_{str[0]} {}
 
   std::vector<Token<charT>> Scanner() {
     std::vector<Token<charT>> tokens;
@@ -926,11 +925,11 @@ class Lexer {
   }
 
   String<charT> str_;
-  size_t pos_;
+  size_t pos_ = 0;
   charT c_;
-  int brace_depth_; // tracks {} nesting
-  int paren_depth_; // tracks () nesting
-  int bracket_depth_; // tracks [] nesting
+  int brace_depth_ = 0; // tracks {} nesting
+  int paren_depth_ = 0; // tracks () nesting
+  int bracket_depth_ = 0; // tracks [] nesting
 };
 
 

--- a/include/glob-cpp/glob.h
+++ b/include/glob-cpp/glob.h
@@ -7,18 +7,6 @@
 #include <memory>
 #include <utility>
 
-#define GLOB_DEBUG 0
-
-#ifndef GLOB_DEBUG
-    #define GLOB_DEBUG 0
-#endif
-#if GLOB_DEBUG
-    #include <iostream>
-    #define GLOB_LOG(x) std::cerr << "[GLOB] " << x << std::endl
-#else
-    #define GLOB_LOG(x)
-#endif
-
 namespace glob {
 
 template<class charT>
@@ -215,8 +203,6 @@ class Automata {
     auto state = std::unique_ptr<State<charT>>(new T(*this,
         std::forward<Args>(args)...));
 
-    GLOB_LOG("NewState created, type: " << static_cast<int>(state->Type()) << ", pos: " << state_pos);
-
     states_.push_back(std::move(state));
 
     return state_pos;
@@ -226,10 +212,6 @@ class Automata {
  private:
   std::tuple<bool, size_t> ExecAux(const String<charT>& str,
       bool comp_end = true) const {
-    GLOB_LOG("=== Automata::ExecAux ===");
-    GLOB_LOG("  String: '" << str << "' (len=" << str.length() << ")");
-    GLOB_LOG("  comp_end: " << (comp_end ? "true" : "false"));
-
     size_t state_pos = 0;
     size_t str_pos = 0;
 
@@ -237,18 +219,7 @@ class Automata {
     // until the string is all consumed
     while (state_pos != fail_state_ && state_pos != match_state_
            && str_pos < str.length()) {
-      GLOB_LOG("  State=" << state_pos << " StrPos=" << str_pos 
-               << " Char='" << (str_pos < str.length() ? str[str_pos] : '?') << "'");
-
       std::tie(state_pos, str_pos) = states_[state_pos]->Next(str, str_pos);
-      
-      if (state_pos == fail_state_) {
-        GLOB_LOG("  -> FAIL_STATE");
-      } else if (state_pos == match_state_) {
-        GLOB_LOG("  -> MATCH_STATE");
-      } else {
-        GLOB_LOG("  -> State=" << state_pos << " StrPos=" << str_pos);
-      }
     }
 
     // If we've consumed the entire string but haven't reached match or fail state,
@@ -258,14 +229,12 @@ class Automata {
       StateType state_type = current_state.Type();
       
       if (state_type == StateType::MULT) {
-      	GLOB_LOG("Automata::ExecAux post loop check for StateType::MULT");
         // Handle star state: check if it has MATCH as its next state (index 1)
         const auto& next_states = current_state.GetNextStates();
         if (next_states.size() > 1 && states_[next_states[1]]->Type() == StateType::MATCH) {
           state_pos = next_states[1];
         }
       } else if (state_type == StateType::GROUP) {
-      	GLOB_LOG("Automata::ExecAux post loop check for StateType::GROUP");
         // Handle group state: it may match empty alternative (e.g., {,.bak})
         // Call Next() which is safe for StateGroup
         size_t next_state_pos, next_str_pos;
@@ -284,14 +253,10 @@ class Automata {
     bool result = false;
     if (comp_end) {
       result = (state_pos == match_state_) && (str_pos == str.length());
-      GLOB_LOG("  Final: state=" << state_pos << " match_state=" << match_state_ 
-               << " str_pos=" << str_pos << " str.length=" << str.length());
-      GLOB_LOG("  Result: " << (result ? "MATCH" : "NO MATCH"));
     } else {
       // if comp_end is false, compare only if the states reached the
       // match state
       result = (state_pos == match_state_);
-      GLOB_LOG("  Result (no comp_end): " << (result ? "MATCH" : "NO MATCH"));
     }
     
     return std::tuple<bool, size_t>(result, str_pos);
@@ -509,25 +474,20 @@ class StateGroup: public State<charT> {
   std::tuple<bool, size_t> BasicCheck(const String<charT>& str,
       size_t pos) {
     String<charT> str_part = str.substr(pos);
-    GLOB_LOG("    StateGroup::BasicCheck: str_part='" << str_part << "' (" << automatas_.size() << " alternatives)");
     
     bool any_match = false;
     size_t longest_match_pos = 0;
     
-    int alt_num = 0;
     for (auto& automata : automatas_) {
-      GLOB_LOG("      Trying alternative " << alt_num);
       bool r;
       size_t str_pos;
       std::tie(r, str_pos) = automata->Exec(str_part, false);
-      GLOB_LOG("      Alternative " << alt_num << " result: " << (r ? "MATCH" : "NO MATCH") << " consumed=" << str_pos);
       
       if (r) {
         any_match = true;
         // Keep track of the longest match
         if (str_pos > longest_match_pos) {
           longest_match_pos = str_pos;
-          GLOB_LOG("      New longest match: " << longest_match_pos);
             
           // If we consumed all remaining characters,
           // we can't find a longer match, so stop here
@@ -536,15 +496,12 @@ class StateGroup: public State<charT> {
           }
         }
       }
-      alt_num++;
     }
 
     if (any_match) {
-      GLOB_LOG("    StateGroup::BasicCheck: SUCCESS, longest match consumed=" << longest_match_pos);
       return std::tuple<bool, size_t>(true, pos + longest_match_pos);
     }
     
-    GLOB_LOG("    StateGroup::BasicCheck: ALL FAILED");
     return std::tuple<bool, size_t>(false, pos);
   }
   
@@ -789,8 +746,6 @@ class Lexer {
 
   std::vector<Token<charT>> Scanner() {
     std::vector<Token<charT>> tokens;
-    GLOB_LOG("=== Starting Lexer ===");
-    GLOB_LOG("Pattern: " << str_);
     while(true) {
       switch (c_) {
         case '?': {
@@ -819,7 +774,6 @@ class Lexer {
 
 		case '{': {
           brace_depth_++;
-          GLOB_LOG("LBRACE (depth now: " << brace_depth_ << ")");
           tokens.push_back(Select(TokenKind::LBRACE));
           Advance();
           break;
@@ -829,7 +783,6 @@ class Lexer {
           if (brace_depth_ > 0) {
             brace_depth_--;
           }
-          GLOB_LOG("RBRACE (depth now: " << brace_depth_ << ")");
           tokens.push_back(Select(TokenKind::RBRACE));
           Advance();
           break;
@@ -872,10 +825,8 @@ class Lexer {
         case ',': {
           // Only UNION inside braces, otherwise regular char
           if (brace_depth_ > 0) {
-            GLOB_LOG("COMMA -> UNION (inside braces)");
             tokens.push_back(Select(TokenKind::UNION));
           } else {
-            GLOB_LOG("COMMA -> CHAR (outside braces)");
             tokens.push_back(Select(TokenKind::CHAR, ','));
           }
           Advance();
@@ -975,12 +926,9 @@ class Lexer {
 
         default: {
           if (c_ == kEndOfInput) {
-            GLOB_LOG("EOS");
             tokens.push_back(Select(TokenKind::EOS));
-            GLOB_LOG("=== Lexer Complete: " << tokens.size() << " tokens ===");
             return tokens;
           } else {
-            GLOB_LOG("CHAR: '" << c_ << "'");
             tokens.push_back(Select(TokenKind::CHAR, c_));
             Advance();
           }
@@ -1475,7 +1423,6 @@ class Parser {
   }
 
   AstNodePtr<charT> ParserBraceGroup() {
-    GLOB_LOG("=== ParserBraceGroup START ===");
     Token<charT>& tk = NextToken();
     if (tk != TokenKind::LBRACE) {
       throw Error("Expected '{'");
@@ -1488,71 +1435,53 @@ class Parser {
       throw Error("Expected '}' at end of brace group");
     }
 
-    GLOB_LOG("=== ParserBraceGroup END ===");
     // Treat brace groups as BASIC groups (matches if any alternative matches)
     return AstNodePtr<charT>(new GroupNode<charT>(
         GroupNode<charT>::GroupType::BASIC, std::move(group_content)));
   }
 
   AstNodePtr<charT> ParserBraceUnion() {
-    GLOB_LOG("=== ParserBraceUnion START ===");
     std::vector<AstNodePtr<charT>> items;
     
     // Parse first item
     AstNodePtr<charT> first_item = ParserBraceItem();
-    int count = 0;
     
     // If it's a UnionNode (from range expansion), flatten its alternatives
     if (first_item->GetType() == AstNode<charT>::Type::UNION) {
-      GLOB_LOG("  UnionNode is a UNION, flattening");
       UnionNode<charT>* union_node = static_cast<UnionNode<charT>*>(first_item.get());
       // Move all alternatives from the nested union into our items vector
       for (auto& item : union_node->GetItems()) {
         items.push_back(std::move(item));
-        count++;
-        GLOB_LOG("  Added inner item " << count);
       }
     } else {
       items.push_back(std::move(first_item));
-      count++;
-      GLOB_LOG("  Added item " << count);
     }
 
     // Parse additional comma-separated items
     while (GetToken() == TokenKind::UNION) {
-      GLOB_LOG("  Found UNION token");
       Advance();
       AstNodePtr<charT> item = ParserBraceItem();
       
       // Flatten any UnionNodes from range expansion
       if (item->GetType() == AstNode<charT>::Type::UNION) {
-      	GLOB_LOG("  UnionNode is a UNION, flattening");
         UnionNode<charT>* union_node = static_cast<UnionNode<charT>*>(item.get());
         for (auto& inner_item : union_node->GetItems()) {
           items.push_back(std::move(inner_item));
-          count++;
-          GLOB_LOG("  Added inner item " << count);
         }
       } else {
         items.push_back(std::move(item));
-        count++;
-        GLOB_LOG("  Added item " << count);
       }
     }
 
-    GLOB_LOG("=== ParserBraceUnion END: " << count << " items ===");
     return AstNodePtr<charT>(new UnionNode<charT>(std::move(items)));
   }
   
   AstNodePtr<charT> ParserBraceItem() {
-    GLOB_LOG("=== ParserBraceItem START ===");
     // Check if this is a range expression (e.g., a..z)
     if (GetToken() == TokenKind::CHAR && PeekAhead() == TokenKind::DOTDOT) {
-      GLOB_LOG("  Detected RANGE");
       return ParserBraceRange();
     }
     
-    GLOB_LOG("  Parsing as CONCAT");
     // Otherwise parse as concatenated characters within this alternative
     return ParserBraceConcat();
   }
@@ -1599,7 +1528,6 @@ class Parser {
   }
 
   AstNodePtr<charT> ParserBraceConcat() {
-    GLOB_LOG("=== ParserBraceConcat START ===");
     auto is_brace_terminator = [&]() -> bool {
       Token<charT>& tk = GetToken();
       return tk == TokenKind::RBRACE || 
@@ -1608,56 +1536,45 @@ class Parser {
     };
 
     std::vector<AstNodePtr<charT>> parts;
-    int part_num = 0;
 
     while (!is_brace_terminator()) {
       // Only allow basic glob patterns within brace alternatives
       Token<charT>& tk = GetToken();
-      GLOB_LOG("  Part " << part_num << ": " << tk);
       
       switch (tk.Kind()) {
         case TokenKind::CHAR:
-          GLOB_LOG("    CHAR: '" << tk.Value() << "'");
           parts.push_back(ParserChar());
           break;
           
         case TokenKind::QUESTION:
-          GLOB_LOG("    QUESTION");
           Advance();
           parts.push_back(AstNodePtr<charT>(new AnyNode<charT>()));
           break;
           
         case TokenKind::STAR:
-          GLOB_LOG("    STAR");
           Advance();
           parts.push_back(AstNodePtr<charT>(new StarNode<charT>()));
           break;
           
         case TokenKind::LBRACKET:
         case TokenKind::NEGLBRACKET:
-          GLOB_LOG("    SET");
           parts.push_back(ParserSet());
           break;
           
         case TokenKind::LBRACE:
-          GLOB_LOG("    NESTED BRACE");
           // Allow nested braces
           parts.push_back(ParserBraceGroup());
           break;
           
         case TokenKind::SUB:
-          GLOB_LOG("    SUB");
           Advance();
           parts.push_back(AstNodePtr<charT>(new CharNode<charT>('-')));
           break;
           
         default:
-          GLOB_LOG("    ERROR: Unexpected token");
           throw Error("Unexpected token in brace alternative");
       }
     }
-
-    GLOB_LOG("=== ParserBraceConcat END: " << part_num << " parts (empty=" << (parts.empty() ? "yes" : "no") << ") ===");
 
     // Handle empty alternative (e.g., {,.bak})
     if (parts.empty()) {
@@ -1782,7 +1699,6 @@ class AstConsumer {
     for (auto& basic_glob : basic_globs) {
       ExecBasicGlob(basic_glob.get(), automata);
     }
-    GLOB_LOG("ExecConcat finished, preview_state_: " << preview_state_);
   }
 
   void ExecBasicGlob(AstNode<charT>* node, Automata<charT>& automata) {
@@ -1930,16 +1846,12 @@ class AstConsumer {
       AstNode<charT>* node) {
     UnionNode<charT>* union_node = static_cast<UnionNode<charT>*>(node);
     auto& items = union_node->GetItems();
-    GLOB_LOG("=== ExecUnion: Processing " << items.size() << " alternatives ===");
     std::vector<std::unique_ptr<Automata<charT>>> vec_automatas;
-    int alt_num = 0;
 
     for (auto& item : items) {
-      GLOB_LOG("  Alternative " << alt_num << ": Type=" << static_cast<int>(item->GetType()));
       std::unique_ptr<Automata<charT>> automata_ptr(new Automata<charT>);
       AstConsumer ast_consumer;
       ast_consumer.ExecConcat(item.get(), *automata_ptr);
-      GLOB_LOG("ExecUnion for item, preview_state_: " << ast_consumer.preview_state_);
   
       size_t match_state = automata_ptr->template NewState<StateMatch<charT>>();
       
@@ -1960,10 +1872,8 @@ class AstConsumer {
       automata_ptr->SetFailState(fail_state);
   
       vec_automatas.push_back(std::move(automata_ptr));
-      alt_num++;
     }
 
-    GLOB_LOG("=== ExecUnion: Created " << vec_automatas.size() << " automata ===");
     return vec_automatas;
   }
 

--- a/include/glob-cpp/token.def
+++ b/include/glob-cpp/token.def
@@ -19,5 +19,6 @@ TOKEN(RBRACKET,    "]")
 TOKEN(NEGLBRACKET, "[^")
 TOKEN(LBRACE,      "{")
 TOKEN(RBRACE,      "}")
+TOKEN(DOTDOT,      "..")
 
 #undef TOKEN

--- a/tests/glob-test.sh
+++ b/tests/glob-test.sh
@@ -664,6 +664,53 @@ test_glob_brace "*.{h,hpp,c,cpp}" "file.txt" "false" "BraceExpansionMultipleItem
 test_glob_brace "*.{h,hpp,c,cpp}" "file.hh" "false" "BraceExpansionMultipleItems: *.{h,hpp,c,cpp} does not match file.hh"
 echo ""
 
+# Test: BraceExpansionGreedyMatching (CRITICAL TEST!)
+echo "Test: BraceExpansionGreedyMatching"
+test_glob_brace "*.{c,cp,cpp}" "file.c" "true" "BraceExpansionGreedyMatching: *.{c,cp,cpp} matches file.c (shortest when only option)"
+test_glob_brace "*.{c,cp,cpp}" "file.cp" "true" "BraceExpansionGreedyMatching: *.{c,cp,cpp} matches file.cp (greedy: matches cp not just c)"
+test_glob_brace "*.{c,cp,cpp}" "file.cpp" "true" "BraceExpansionGreedyMatching: *.{c,cp,cpp} matches file.cpp (longest match)"
+test_glob_brace "*.{c,cp,cpp}" "file.cxx" "false" "BraceExpansionGreedyMatching: *.{c,cp,cpp} does not match file.cxx"
+echo ""
+
+# Test: BraceExpansionComplexList
+echo "Test: BraceExpansionComplexList"
+test_glob_brace "*.{h,hp,hpp,hxx,c,cc,cp,cpp,cxx}" "foo.h" "true" "BraceExpansionComplexList: Complex list matches foo.h"
+test_glob_brace "*.{h,hp,hpp,hxx,c,cc,cp,cpp,cxx}" "foo.hp" "true" "BraceExpansionComplexList: Complex list matches foo.hp"
+test_glob_brace "*.{h,hp,hpp,hxx,c,cc,cp,cpp,cxx}" "foo.hpp" "true" "BraceExpansionComplexList: Complex list matches foo.hpp"
+test_glob_brace "*.{h,hp,hpp,hxx,c,cc,cp,cpp,cxx}" "foo.hxx" "true" "BraceExpansionComplexList: Complex list matches foo.hxx"
+test_glob_brace "*.{h,hp,hpp,hxx,c,cc,cp,cpp,cxx}" "foo.c" "true" "BraceExpansionComplexList: Complex list matches foo.c"
+test_glob_brace "*.{h,hp,hpp,hxx,c,cc,cp,cpp,cxx}" "foo.cc" "true" "BraceExpansionComplexList: Complex list matches foo.cc"
+test_glob_brace "*.{h,hp,hpp,hxx,c,cc,cp,cpp,cxx}" "foo.cp" "true" "BraceExpansionComplexList: Complex list matches foo.cp (CRITICAL!)"
+test_glob_brace "*.{h,hp,hpp,hxx,c,cc,cp,cpp,cxx}" "foo.cpp" "true" "BraceExpansionComplexList: Complex list matches foo.cpp"
+test_glob_brace "*.{h,hp,hpp,hxx,c,cc,cp,cpp,cxx}" "foo.cxx" "true" "BraceExpansionComplexList: Complex list matches foo.cxx"
+test_glob_brace "*.{h,hp,hpp,hxx,c,cc,cp,cpp,cxx}" "foo.java" "false" "BraceExpansionComplexList: Complex list does not match foo.java"
+echo ""
+
+# Test: BraceExpansionRanges
+echo "Test: BraceExpansionRanges"
+test_glob_brace "file{1..3}.txt" "file1.txt" "true" "BraceExpansionRanges: file{1..3}.txt matches file1.txt"
+test_glob_brace "file{1..3}.txt" "file2.txt" "true" "BraceExpansionRanges: file{1..3}.txt matches file2.txt"
+test_glob_brace "file{1..3}.txt" "file3.txt" "true" "BraceExpansionRanges: file{1..3}.txt matches file3.txt"
+test_glob_brace "file{1..3}.txt" "file0.txt" "false" "BraceExpansionRanges: file{1..3}.txt does not match file0.txt"
+test_glob_brace "file{1..3}.txt" "file4.txt" "false" "BraceExpansionRanges: file{1..3}.txt does not match file4.txt"
+echo ""
+
+# Test: BraceExpansionCharRange
+echo "Test: BraceExpansionCharRange"
+test_glob_brace "test{a..c}.log" "testa.log" "true" "BraceExpansionCharRange: test{a..c}.log matches testa.log"
+test_glob_brace "test{a..c}.log" "testb.log" "true" "BraceExpansionCharRange: test{a..c}.log matches testb.log"
+test_glob_brace "test{a..c}.log" "testc.log" "true" "BraceExpansionCharRange: test{a..c}.log matches testc.log"
+test_glob_brace "test{a..c}.log" "testd.log" "false" "BraceExpansionCharRange: test{a..c}.log does not match testd.log"
+echo ""
+
+# Test: BraceExpansionReverseRange
+echo "Test: BraceExpansionReverseRange"
+test_glob_brace "file{5..1}.txt" "file5.txt" "true" "BraceExpansionReverseRange: file{5..1}.txt matches file5.txt"
+test_glob_brace "file{5..1}.txt" "file3.txt" "true" "BraceExpansionReverseRange: file{5..1}.txt matches file3.txt"
+test_glob_brace "file{5..1}.txt" "file1.txt" "true" "BraceExpansionReverseRange: file{5..1}.txt matches file1.txt"
+test_glob_brace "file{5..1}.txt" "file0.txt" "false" "BraceExpansionReverseRange: file{5..1}.txt does not match file0.txt"
+echo ""
+
 # Test: BraceExpansionWithPrefix
 echo "Test: BraceExpansionWithPrefix"
 test_glob_brace "test.{txt,md}" "test.txt" "true" "BraceExpansionWithPrefix: test.{txt,md} matches test.txt"
@@ -714,6 +761,35 @@ test_glob_brace "{a,b{1,2}}*.txt" "b2.txt" "true" "BraceExpansionNestedComplex: 
 test_glob_brace "{a,b{1,2}}*.txt" "afile.txt" "true" "BraceExpansionNestedComplex: {a,b{1,2}}*.txt matches afile.txt"
 test_glob_brace "{a,b{1,2}}*.txt" "b1test.txt" "true" "BraceExpansionNestedComplex: {a,b{1,2}}*.txt matches b1test.txt"
 test_glob_brace "{a,b{1,2}}*.txt" "b.txt" "false" "BraceExpansionNestedComplex: {a,b{1,2}}*.txt does not match b.txt"
+echo ""
+
+# Test: BraceExpansionNestedPaths
+echo "Test: BraceExpansionNestedPaths"
+test_glob_brace "{test,prod}/{log,data}.txt" "test/log.txt" "true" "BraceExpansionNestedPaths: {test,prod}/{log,data}.txt matches test/log.txt"
+test_glob_brace "{test,prod}/{log,data}.txt" "test/data.txt" "true" "BraceExpansionNestedPaths: {test,prod}/{log,data}.txt matches test/data.txt"
+test_glob_brace "{test,prod}/{log,data}.txt" "prod/log.txt" "true" "BraceExpansionNestedPaths: {test,prod}/{log,data}.txt matches prod/log.txt"
+test_glob_brace "{test,prod}/{log,data}.txt" "prod/data.txt" "true" "BraceExpansionNestedPaths: {test,prod}/{log,data}.txt matches prod/data.txt"
+test_glob_brace "{test,prod}/{log,data}.txt" "dev/log.txt" "false" "BraceExpansionNestedPaths: {test,prod}/{log,data}.txt does not match dev/log.txt"
+echo ""
+
+# Test: BraceExpansionMultipleRanges
+echo "Test: BraceExpansionMultipleRanges"
+test_glob_brace "file{1..2}{a..b}.txt" "file1a.txt" "true" "BraceExpansionMultipleRanges: file{1..2}{a..b}.txt matches file1a.txt"
+test_glob_brace "file{1..2}{a..b}.txt" "file1b.txt" "true" "BraceExpansionMultipleRanges: file{1..2}{a..b}.txt matches file1b.txt"
+test_glob_brace "file{1..2}{a..b}.txt" "file2a.txt" "true" "BraceExpansionMultipleRanges: file{1..2}{a..b}.txt matches file2a.txt"
+test_glob_brace "file{1..2}{a..b}.txt" "file2b.txt" "true" "BraceExpansionMultipleRanges: file{1..2}{a..b}.txt matches file2b.txt"
+test_glob_brace "file{1..2}{a..b}.txt" "file1c.txt" "false" "BraceExpansionMultipleRanges: file{1..2}{a..b}.txt does not match file1c.txt"
+echo ""
+
+# Test: BraceExpansionComplexNested
+echo "Test: BraceExpansionComplexNested"
+test_glob_brace "{a,b}{c{d,e},f}" "acd" "true" "BraceExpansionComplexNested: {a,b}{c{d,e},f} matches acd"
+test_glob_brace "{a,b}{c{d,e},f}" "ace" "true" "BraceExpansionComplexNested: {a,b}{c{d,e},f} matches ace"
+test_glob_brace "{a,b}{c{d,e},f}" "af" "true" "BraceExpansionComplexNested: {a,b}{c{d,e},f} matches af"
+test_glob_brace "{a,b}{c{d,e},f}" "bcd" "true" "BraceExpansionComplexNested: {a,b}{c{d,e},f} matches bcd"
+test_glob_brace "{a,b}{c{d,e},f}" "bce" "true" "BraceExpansionComplexNested: {a,b}{c{d,e},f} matches bce"
+test_glob_brace "{a,b}{c{d,e},f}" "bf" "true" "BraceExpansionComplexNested: {a,b}{c{d,e},f} matches bf"
+test_glob_brace "{a,b}{c{d,e},f}" "ac" "false" "BraceExpansionComplexNested: {a,b}{c{d,e},f} does not match ac"
 echo ""
 
 # Test: BraceExpansionEmptyBraces
@@ -832,6 +908,60 @@ test_glob_brace "?{a,b}.txt" "xa.txt" "true" "?{a,b}.txt matches xa.txt"
 test_glob_brace "?{a,b}.txt" "xb.txt" "true" "?{a,b}.txt matches xb.txt"
 test_glob_brace "{a,b}*.txt" "a123.txt" "true" "{a,b}*.txt matches a123.txt"
 test_glob_brace "{a,b}*.txt" "b.txt" "true" "{a,b}*.txt matches b.txt"
+echo ""
+
+# ============================================================================
+# CONTEXT-AWARE TOKENIZATION TESTS
+# ============================================================================
+
+echo "Test: Context-Aware - Comma"
+test_glob "foo,bar" "foo,bar" "true" "Comma outside braces is literal"
+test_glob "foo,bar" "foo" "false" "Comma outside braces doesn't separate"
+test_glob "foo,bar" "foobar" "false" "Comma is not optional"
+test_glob "*,*" "a,b" "true" "Comma literal with wildcards"
+test_glob "*,*" "ab" "false" "Comma required when literal"
+echo ""
+
+echo "Test: Context-Aware - Pipe"
+test_glob "foo|bar" "foo|bar" "true" "Pipe outside parens is literal"
+test_glob "foo|bar" "foo" "false" "Pipe outside parens doesn't separate"
+test_glob "foo|bar" "bar" "false" "Pipe outside parens doesn't separate"
+test_glob "*|*" "a|b" "true" "Pipe literal with wildcards"
+test_glob "*|*" "ab" "false" "Pipe required when literal"
+echo ""
+
+echo "Test: Context-Aware - Double Dot"
+test_glob "test..txt" "test..txt" "true" "Double dot outside braces is literal"
+test_glob "test..txt" "test.txt" "false" "Double dot doesn't match single dot"
+test_glob "test..txt" "testXtxt" "false" "Double dot is not a wildcard"
+test_glob "*.." "file.." "true" "Double dot at end is literal"
+test_glob "..txt" "..txt" "true" "Double dot at start is literal"
+echo ""
+
+echo "Test: Context-Aware - Hyphen/Dash"
+test_glob "foo-bar" "foo-bar" "true" "Hyphen outside brackets is literal"
+test_glob "foo-bar" "foobar" "false" "Hyphen is not optional"
+test_glob "*-*" "a-b" "true" "Hyphen literal with wildcards"
+test_glob "test-[0-9]" "test-5" "true" "Hyphen literal before bracket, range inside"
+test_glob "test-[0-9]" "test5" "false" "Hyphen required before bracket"
+echo ""
+
+echo "Test: Context-Aware - Plus"
+test_glob "foo+bar" "foo+bar" "true" "Plus without parens is literal"
+test_glob "foo+bar" "foobar" "false" "Plus is not optional"
+test_glob "*+*" "a+b" "true" "Plus literal with wildcards"
+echo ""
+
+echo "Test: Context-Aware - At Symbol"
+test_glob "user@host" "user@host" "true" "At symbol without parens is literal"
+test_glob "user@host" "userhost" "false" "At symbol is not optional"
+test_glob "*@*" "a@b" "true" "At symbol literal with wildcards"
+echo ""
+
+echo "Test: Context-Aware - Exclamation"
+test_glob "wow!" "wow!" "true" "Exclamation without parens is literal"
+test_glob "wow!" "wow" "false" "Exclamation is not optional"
+test_glob "*!" "test!" "true" "Exclamation literal with wildcards"
 echo ""
 
 # ============================================================================


### PR DESCRIPTION
Alternative brace expansion implementation

The benefits:
Uses existing parser architecture with minimal changes  - {a,b} creates same node tree as (a|b)
No multiple pattern explosion with cloning of nodes
No special cases - works naturally through existing code paths
Context-aware tokenization `- ,` become UNION only inside {}; `|` becomes UNION only inside ()
Range expansion - {a..z} expanded at parse time into union
Greedy matching fix - Modified BasicCheck() to try all alternatives and pick longest match

Added new tests for range expansion.
The new implementation passes 42 more tests than the original implementation without regressing. No crashes.