### PR TITLE
Add globstar (**) support with recursive directory matching + empty pattern fix

### DIFF
--- a/examples/glob.xcodeproj/xcshareddata/xcschemes/glob.xcscheme
+++ b/examples/glob.xcodeproj/xcshareddata/xcschemes/glob.xcscheme
@@ -57,20 +57,20 @@
             isEnabled = "NO">
          </CommandLineArgument>
          <CommandLineArgument
-            argument = "bar/baz/foo.cpp"
-            isEnabled = "NO">
-         </CommandLineArgument>
-         <CommandLineArgument
             argument = "**/*.cpp"
+            isEnabled = "YES">
+         </CommandLineArgument>
+         <CommandLineArgument
+            argument = "&apos;&apos;"
             isEnabled = "NO">
          </CommandLineArgument>
          <CommandLineArgument
             argument = "bar/baz/foo.cpp"
-            isEnabled = "NO">
+            isEnabled = "YES">
          </CommandLineArgument>
          <CommandLineArgument
             argument = "*.{h,hp,hpp,hxx,c,cc,cp,cpp,cxx}"
-            isEnabled = "YES">
+            isEnabled = "NO">
          </CommandLineArgument>
          <CommandLineArgument
             argument = "*.@(h|hp|hpp|hxx|c|cc|cp|cpp|cxx)"
@@ -78,7 +78,7 @@
          </CommandLineArgument>
          <CommandLineArgument
             argument = "foo.hp"
-            isEnabled = "YES">
+            isEnabled = "NO">
          </CommandLineArgument>
          <CommandLineArgument
             argument = "[A-Z]*.cpp"
@@ -97,11 +97,23 @@
             isEnabled = "NO">
          </CommandLineArgument>
          <CommandLineArgument
+            argument = "**/baz/**.cpp"
+            isEnabled = "NO">
+         </CommandLineArgument>
+         <CommandLineArgument
             argument = "*/baz**/*.cpp"
             isEnabled = "NO">
          </CommandLineArgument>
          <CommandLineArgument
             argument = "bar/baz/foo.cpp"
+            isEnabled = "NO">
+         </CommandLineArgument>
+         <CommandLineArgument
+            argument = "**/"
+            isEnabled = "NO">
+         </CommandLineArgument>
+         <CommandLineArgument
+            argument = "dir/sub/file.txt"
             isEnabled = "NO">
          </CommandLineArgument>
          <CommandLineArgument
@@ -142,6 +154,14 @@
          </CommandLineArgument>
          <CommandLineArgument
             argument = "A.txt"
+            isEnabled = "NO">
+         </CommandLineArgument>
+         <CommandLineArgument
+            argument = "https://**.google.com"
+            isEnabled = "NO">
+         </CommandLineArgument>
+         <CommandLineArgument
+            argument = "https://foo.bar.google.com"
             isEnabled = "NO">
          </CommandLineArgument>
       </CommandLineArguments>

--- a/tests/glob-str-test.cc
+++ b/tests/glob-str-test.cc
@@ -457,6 +457,12 @@ TEST_F(GlobTestFixture, ZeroLengthMatch) {
   EXPECT_TRUE(glob::glob_match("testtest", g));
 }
 
+TEST_F(GlobTestFixture, EmptyPattern) {
+  glob::glob g("");
+  EXPECT_TRUE(glob::glob_match("", g));
+  EXPECT_FALSE(glob::glob_match("test", g));
+}
+
 // ============================================================================
 // Wide Character Tests
 // ============================================================================


### PR DESCRIPTION
This change adds support for globstar (**) patterns, enabling recursive directory matching (zero or more directories) as in Bash globstar, Gitignore, and Node.js minimatch.

Globstar implementation:
Standalone ** components enable recursive matching over path components
Non-standalone ** (e.g., **.cpp) collapse to * (Bash-like behavior).
Trailing / in **/ matches directories only.

Empty pattern fix:
Lexer guarded against empty strings (crash in Advance() on trailing / parts).

Tests:
Added new globstar tests
Added empty pattern tests to ensure no crashes and correct no-match behavior.

The zero-length pattern crash is:

```
thread #1, queue = 'com.apple.main-thread', stop reason = signal SIGABRT
    frame #0: 0x000000018acfb5b0 libsystem_kernel.dylib__pthread_kill + 8
    frame #1: 0x0000000100106660 libsystem_pthread.dylibpthread_kill + 296
    frame #2: 0x000000018ac3a850 libsystem_c.dylibabort + 124   * frame #3: 0x0000000100005f20 globstd::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char>>::operator[][abi:de200100](this="", __pos=1) at string:1363:5
    frame #4: 0x0000000100006318 globglob::Lexer<char>::Advance(this=0x000000016fdfe8e0) at glob.h:1044:10
    frame #5: 0x0000000100003ed4 globglob::Lexer<char>::Scanner(this=0x000000016fdfe8e0) at glob.h:1022:13
    frame #6: 0x0000000100002920 globglob::ExtendedGlob<char>::ExtendedGlob(this=0x00000001008f1fa0, pattern="") at glob.h:2003:50
    frame #7: 0x00000001000027a4 globglob::ExtendedGlob<char>::ExtendedGlob(this=0x00000001008f1fa0, pattern="") at glob.h:1988:64
    frame #8: 0x00000001000045cc globstd::__1::unique_ptr<glob::ExtendedGlob<char>, std::__1::default_delete<glob::ExtendedGlob<char>>> std::__1::make_unique[abi:de200100]<glob::ExtendedGlob<char>, std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char>>&, 0>(__args="") at unique_ptr.h:767:30
    frame #9: 0x0000000100002bdc globglob::ExtendedGlob<char>::ExtendedGlob(this=0x000000016fdfedb0, pattern="**/") at glob.h:2023:38
    frame #10: 0x00000001000027a4 globglob::ExtendedGlob<char>::ExtendedGlob(this=0x000000016fdfedb0, pattern="**/") at glob.h:1988:64
    frame #11: 0x0000000100002770 globglob::BasicGlob<char, glob::ExtendedGlob<char>>::BasicGlob(this=0x000000016fdfedb0, pattern="**/") at glob.h:2223:6
    frame #12: 0x0000000100000a74 globglob::BasicGlob<char, glob::ExtendedGlob<char>>::BasicGlob(this=0x000000016fdfedb0, pattern="**/") at glob.h:2223:21
    frame #13: 0x0000000100000794 globmain(argc=3, argv=0x000000016fdff510) at string-match-cli.cc:16:16
    frame #14: 0x000000018a96dd54 dyld`start + 7184
```
