### PR TITLE
Rename macros starting with GLOBSTAR_ to GLOBCPP_

### DIFF
--- a/include/glob-cpp/glob.h
+++ b/include/glob-cpp/glob.h
@@ -11,55 +11,55 @@
 // ============================================================================
 // Exception Handling Policy Configuration
 // ============================================================================
-// Client controls exception handling via GLOBSTAR_NOEXCEPT_ENABLED:
+// Client controls exception handling via GLOBCPP_NOEXCEPT_ENABLED:
 //
-// GLOBSTAR_NOEXCEPT_ENABLED 1 (default):
+// GLOBCPP_NOEXCEPT_ENABLED 1 (default):
 //   - Public API functions are noexcept
 //   - Exceptions caught and logged internally
 //   - Safe fallback behavior on errors
 //
-// GLOBSTAR_NOEXCEPT_ENABLED 0:
+// GLOBCPP_NOEXCEPT_ENABLED 0:
 //   - Functions can throw
 //   - Exceptions propagate naturally
 //   - Better for debugging with full stack traces
 //
-// GLOBSTAR_EXCEPTION_LOG:
-//   - Customize logging (only used when GLOBSTAR_NOEXCEPT_ENABLED is 1)
+// GLOBCPP_EXCEPTION_LOG:
+//   - Customize logging (only used when GLOBCPP_NOEXCEPT_ENABLED is 1)
 //   - Default: logs to stderr using std::cerr
-//   - Example: #define GLOBSTAR_EXCEPTION_LOG(context, message) my_log(context, message)
+//   - Example: #define GLOBCPP_EXCEPTION_LOG(context, message) my_log(context, message)
 // ============================================================================
 
-#ifndef GLOBSTAR_NOEXCEPT_ENABLED
-  #define GLOBSTAR_NOEXCEPT_ENABLED 1
+#ifndef GLOBCPP_NOEXCEPT_ENABLED
+  #define GLOBCPP_NOEXCEPT_ENABLED 1
 #endif
 
-#if GLOBSTAR_NOEXCEPT_ENABLED
+#if GLOBCPP_NOEXCEPT_ENABLED
 
   // ========== NOEXCEPT MODE ==========
-  #define GLOBSTAR_NOEXCEPT noexcept
-  #define GLOBSTAR_TRY try
+  #define GLOBCPP_NOEXCEPT noexcept
+  #define GLOBCPP_TRY try
 
-  #ifndef GLOBSTAR_EXCEPTION_LOG
-    #define GLOBSTAR_EXCEPTION_LOG(context, ex_what) \
+  #ifndef GLOBCPP_EXCEPTION_LOG
+    #define GLOBCPP_EXCEPTION_LOG(context, ex_what) \
       std::cerr << "[glob-cpp] Exception in " << context << ": " << ex_what << std::endl
   #endif
 
-  #define GLOBSTAR_CATCH_AND_LOG(context) \
+  #define GLOBCPP_CATCH_AND_LOG(context) \
     catch (const std::exception& e) { \
-      GLOBSTAR_EXCEPTION_LOG(context, e.what()); \
+      GLOBCPP_EXCEPTION_LOG(context, e.what()); \
     } catch (...) { \
-      GLOBSTAR_EXCEPTION_LOG(context, "Unknown exception caught"); \
+      GLOBCPP_EXCEPTION_LOG(context, "Unknown exception caught"); \
     }
 
-#else // GLOBSTAR_NOEXCEPT_ENABLED
+#else // GLOBCPP_NOEXCEPT_ENABLED
 
   // ========== EXCEPTION PROPAGATION MODE ==========
-  #define GLOBSTAR_NOEXCEPT
-  #define GLOBSTAR_TRY
-  #define GLOBSTAR_CATCH_AND_LOG(context)
-  #define GLOBSTAR_EXCEPTION_LOG(context, ex_what) ((void)0)
+  #define GLOBCPP_NOEXCEPT
+  #define GLOBCPP_TRY
+  #define GLOBCPP_CATCH_AND_LOG(context)
+  #define GLOBCPP_EXCEPTION_LOG(context, ex_what) ((void)0)
 
-#endif // GLOBSTAR_NOEXCEPT_ENABLED
+#endif // GLOBCPP_NOEXCEPT_ENABLED
 
 namespace glob {
 
@@ -1985,8 +1985,8 @@ class AstConsumer {
 template<class charT>
 class ExtendedGlob {
  public:
-  ExtendedGlob(const String<charT>& pattern) GLOBSTAR_NOEXCEPT {
-    GLOBSTAR_TRY {
+  ExtendedGlob(const String<charT>& pattern) GLOBCPP_NOEXCEPT {
+    GLOBCPP_TRY {
       pattern_parts_ = split_path(pattern);
       for (const auto& part : pattern_parts_) {
         if (part == "**") {
@@ -2026,7 +2026,7 @@ class ExtendedGlob {
       }
       return; // Success
     }
-    GLOBSTAR_CATCH_AND_LOG("ExtendedGlob::ExtendedGlob()")
+    GLOBCPP_CATCH_AND_LOG("ExtendedGlob::ExtendedGlob()")
     
     // Failure path: clear any partial state and create a safe always-fail automata
     has_globstar_ = false;
@@ -2125,12 +2125,12 @@ class ExtendedGlob {
 template<class charT>
 class SimpleGlob {
  public:
-  SimpleGlob(const String<charT>& pattern) GLOBSTAR_NOEXCEPT {
-    GLOBSTAR_TRY {
+  SimpleGlob(const String<charT>& pattern) GLOBCPP_NOEXCEPT {
+    GLOBCPP_TRY {
       Parser(pattern);
       return; // Success
     }
-    GLOBSTAR_CATCH_AND_LOG("SimpleGlob::SimpleGlob()")
+    GLOBCPP_CATCH_AND_LOG("SimpleGlob::SimpleGlob()")
 
     // Failure path: clear any partial state and create a safe always-fail automata
     automata_ = Automata<charT>();  // Reset to empty state
@@ -2219,7 +2219,7 @@ class MatchResults;
 template<class charT, class globT=extended_glob<charT>>
 class BasicGlob {
  public:
-  BasicGlob(const String<charT>& pattern) GLOBSTAR_NOEXCEPT
+  BasicGlob(const String<charT>& pattern) GLOBCPP_NOEXCEPT
    : glob_{pattern} {}
 
   BasicGlob(const BasicGlob&) = delete;
@@ -2238,28 +2238,28 @@ class BasicGlob {
   }
 
  private:
-  bool Exec(const String<charT>& str) GLOBSTAR_NOEXCEPT {
-    GLOBSTAR_TRY {
+  bool Exec(const String<charT>& str) GLOBCPP_NOEXCEPT {
+    GLOBCPP_TRY {
       return glob_.Exec(str);
     }
-    GLOBSTAR_CATCH_AND_LOG("BasicGlob::Exec()")
+    GLOBCPP_CATCH_AND_LOG("BasicGlob::Exec()")
     return false;  // Any execution error means no match
   }
 
   template<class charU, class globU>
   friend bool glob_match(const String<charU>& str,
-      BasicGlob<charU, globU>& glob) GLOBSTAR_NOEXCEPT;
+      BasicGlob<charU, globU>& glob) GLOBCPP_NOEXCEPT;
 
   template<class charU, class globU>
-  friend bool glob_match(const charU* str, BasicGlob<charU, globU>& glob) GLOBSTAR_NOEXCEPT;
+  friend bool glob_match(const charU* str, BasicGlob<charU, globU>& glob) GLOBCPP_NOEXCEPT;
 
   template<class charU, class globU>
   friend bool glob_match(const String<charU>& str, MatchResults<charU>& res,
-      BasicGlob<charU, globU>& glob) GLOBSTAR_NOEXCEPT;
+      BasicGlob<charU, globU>& glob) GLOBCPP_NOEXCEPT;
 
   template<class charU, class globU>
   friend bool glob_match(const charU* str, MatchResults<charU>& res,
-    BasicGlob<charU, globU>& glob) GLOBSTAR_NOEXCEPT;
+    BasicGlob<charU, globU>& glob) GLOBCPP_NOEXCEPT;
 
   globT glob_;
 };
@@ -2320,51 +2320,51 @@ class MatchResults {
 
   template<class charU, class globU>
   friend bool glob_match(const String<charU>& str,
-      BasicGlob<charU, globU>& glob) GLOBSTAR_NOEXCEPT;
+      BasicGlob<charU, globU>& glob) GLOBCPP_NOEXCEPT;
 
   template<class charU, class globU>
-  friend bool glob_match(const charU* str, BasicGlob<charU, globU>& glob) GLOBSTAR_NOEXCEPT;
+  friend bool glob_match(const charU* str, BasicGlob<charU, globU>& glob) GLOBCPP_NOEXCEPT;
 
   template<class charU, class globU>
   friend bool glob_match(const String<charU>& str, MatchResults<charU>& res,
-      BasicGlob<charU, globU>& glob) GLOBSTAR_NOEXCEPT;
+      BasicGlob<charU, globU>& glob) GLOBCPP_NOEXCEPT;
 
   template<class charU, class globU>
   friend bool glob_match(const charU* str, MatchResults<charU>& res,
-    BasicGlob<charU, globU>& glob) GLOBSTAR_NOEXCEPT;
+    BasicGlob<charU, globU>& glob) GLOBCPP_NOEXCEPT;
 
   std::vector<String<charT>> results_;
 };
 
 template<class charT, class globT=extended_glob<charT>>
-bool glob_match(const String<charT>& str, BasicGlob<charT, globT>& glob) GLOBSTAR_NOEXCEPT {
+bool glob_match(const String<charT>& str, BasicGlob<charT, globT>& glob) GLOBCPP_NOEXCEPT {
   return glob.Exec(str);
 }
 
 template<class charT, class globT=extended_glob<charT>>
-bool glob_match(const charT* str, BasicGlob<charT, globT>& glob) GLOBSTAR_NOEXCEPT {
+bool glob_match(const charT* str, BasicGlob<charT, globT>& glob) GLOBCPP_NOEXCEPT {
   return glob.Exec(str);
 }
 
 template<class charT, class globT=extended_glob<charT>>
 bool glob_match(const String<charT>& str, MatchResults<charT>& res,
-    BasicGlob<charT, globT>& glob) GLOBSTAR_NOEXCEPT {
+    BasicGlob<charT, globT>& glob) GLOBCPP_NOEXCEPT {
   bool r = glob.Exec(str);
-  GLOBSTAR_TRY {
+  GLOBCPP_TRY {
       res.SetResults(glob.GetAutomata().GetMatchedStrings());
   }
-  GLOBSTAR_CATCH_AND_LOG("glob_match() - SetResults")
+  GLOBCPP_CATCH_AND_LOG("glob_match() - SetResults")
   return r;
 }
 
 template<class charT, class globT=extended_glob<charT>>
 bool glob_match(const charT* str, MatchResults<charT>& res,
-    BasicGlob<charT, globT>& glob) GLOBSTAR_NOEXCEPT {
+    BasicGlob<charT, globT>& glob) GLOBCPP_NOEXCEPT {
   bool r = glob.Exec(str);
-  GLOBSTAR_TRY {
+  GLOBCPP_TRY {
     res.SetResults(glob.GetAutomata().GetMatchedStrings());
   }
-  GLOBSTAR_CATCH_AND_LOG("glob_match() - SetResults")
+  GLOBCPP_CATCH_AND_LOG("glob_match() - SetResults")
   return r;
 }
 


### PR DESCRIPTION
The macros were developed during the work on globstar feature but they apply to the whole glob-cpp code so a better prefix will be GLOBCPP_