### PR TITLE
Enable greedy backtracking for *

### DIFF
--- a/tests/glob-test.sh
+++ b/tests/glob-test.sh
@@ -1031,7 +1031,7 @@ echo ""
 
 echo "Test: Globstar With Non-Standalone **"
 test_glob "src/**.cpp" "src/foo.cpp" "true" "Globstar with non-standalone: src/**.cpp matches src/foo.cpp (collapses to src/*.cpp)"
-test_glob "src/**.cpp" "src/sub/foo.cpp" "true" "Globstar with non-standalone: src/**.cpp matches src/sub/foo.cpp"
+test_glob "src/**.cpp" "src/sub/foo.cpp" "false" "Globstar with non-standalone: src/**.cpp does not match src/sub/foo.cpp"
 test_glob "src/**.cpp" "src/foo.txt" "false" "Globstar with non-standalone: src/**.cpp does not match src/foo.txt"
 echo ""
 


### PR DESCRIPTION
Enabled greedy backtracking in Automata::Match

The goal is to fix `*.google.com` matching `foo.bar.google.com` without breaking anything else. It proved harder than originally thought.

Implementation:
`ExecAux()` code has been extracted into a separate `Match()` method to be called recursively if needed.
Prioritizes longer * matches, backtracks on failure for correct suffix matching.
Added epsilon handling for repeating groups (*(), +(), ?()) and negation.
Added zero-consumption epsilon force to handle empty/negation groups.

Since the globstar (`**`) is the way to match multiple directories and it is enabled by default without specifying any flag, the regular "any" star is not supposed to cross the directory separator `/` when matching paths. It is not an issue if the glob pattern is used for filenames only. But when used for matching paths this new code changes the `*` behavior to not match across directories.

All tests now pass, including negation, repeating groups, brace expansion, and globstar.