### PR TITLE
Fix ResetState() to clear matched_str_, enabling safe glob reuse

### DIFF
--- a/include/glob-cpp/glob.h
+++ b/include/glob-cpp/glob.h
@@ -186,7 +186,7 @@ class State {
     return matched_str_;
   }
 
-  virtual void ResetState() {}
+  virtual void ResetState() { matched_str_.clear(); }
 
  public:
   void SetMatchedStr(const String<charT>& str) {
@@ -274,6 +274,10 @@ class Automata {
 
   size_t FailState() const {
     return fail_state_;
+  }
+
+  size_t MatchState() const {
+    return match_state_;
   }
 
   Automata<charT>& SetFailState(size_t state_pos) {
@@ -616,6 +620,7 @@ class StateGroup: public State<charT> {
     , match_one_{false} {}
 
   void ResetState() override {
+    State<charT>::ResetState();
     match_one_ = false;
   }
 


### PR DESCRIPTION
Problem

State<charT>::ResetState() was a no-op, and StateGroup<charT>::ResetState() only reset match_one_ — neither cleared matched_str_. This made it unsafe to call Exec() on the same compiled glob object more than once.

The root issue is in the Next() implementations of StateStar and StateGroup, which use an append pattern rather than assignment:

// StateStar::Next()
this->SetMatchedStr(this->MatchedStr() + str[pos]);

// StateGroup::Next*()
this->SetMatchedStr(this->MatchedStr() + str.substr(pos, new_pos - pos));

Within a single Exec() call this is correct — Automata::Match() saves and restores matched_str_ during backtracking. But because ResetStates() called the no-op ResetState(), the accumulated string from a successful match was never cleared between calls.

When the same glob::glob object was reused for multiple Exec() calls (e.g. pre-compiled and called in a loop), matched_str_ grew with every successful match — concatenating the matched substrings from all prior calls. Subsequent calls then:
1. Copied the growing stale string for saved_matched (heap allocation, growing each call)
2. Appended to it in Next() (creating an even larger heap string)

This caused super-linear memory allocation overhead that grew with the number of successful matches, making compiled-glob reuse substantially slower than re-compiling on every call — the opposite of the intended benefit.

Fix

State<charT>::ResetState() now clears matched_str_:

virtual void ResetState() { matched_str_.clear(); }

StateGroup<charT>::ResetState() chains to the base to clear matched_str_ (which is private to State<charT>) before resetting its own match_one_ field:

void ResetState() override {
    State<charT>::ResetState();
    match_one_ = false;
}

Automata::Exec() already calls ResetStates() at the end of every call, so no callers need to change. After this fix, sequential reuse of a compiled glob object is safe and efficient — saved_matched always copies an empty string (SSO, no heap allocation), and Next() always starts accumulation from an empty base.

Also added: Automata::MatchState() const accessor, parallel to the existing FailState().